### PR TITLE
fix quatation marks bug

### DIFF
--- a/src/arxiv.ts
+++ b/src/arxiv.ts
@@ -44,7 +44,7 @@ export async function searchPaper(arxivId: string): Promise<Paper> {
 			.querySelector("summary")
 			?.textContent?.trim()
 			.replace(/\n/g, " ")
-			.replace(/\"/g, "'")|| "No abstract available";
+			.replace(/"/g, "'") || "No abstract available";
 
 	const comments = entry.querySelector("comment")?.textContent?.trim() || "";
 

--- a/src/arxiv.ts
+++ b/src/arxiv.ts
@@ -43,7 +43,8 @@ export async function searchPaper(arxivId: string): Promise<Paper> {
 		entry
 			.querySelector("summary")
 			?.textContent?.trim()
-			.replace(/\n/g, " ") || "No abstract available";
+			.replace(/\n/g, " ")
+			.replace(/\"/g, "'")|| "No abstract available";
 
 	const comments = entry.querySelector("comment")?.textContent?.trim() || "";
 


### PR DESCRIPTION
When abstract contains punctuation ", the created obsidian document will have issue to be viewed in markdown format.


To reproduce:
https://arxiv.org/abs/2411.04905